### PR TITLE
feat: add TOON output format with JMESPath filtering support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@aashari/boilerplate-mcp-server",
-	"version": "1.13.5",
+	"version": "1.14.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@aashari/boilerplate-mcp-server",
-			"version": "1.13.5",
+			"version": "1.14.0",
 			"hasInstallScript": true,
 			"license": "ISC",
 			"dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,10 +11,12 @@
 			"license": "ISC",
 			"dependencies": {
 				"@modelcontextprotocol/sdk": "^1.17.5",
+				"@toon-format/toon": "^2.0.1",
 				"commander": "^14.0.0",
 				"cors": "^2.8.5",
 				"dotenv": "^17.2.2",
 				"express": "^5.1.0",
+				"jmespath": "^0.16.0",
 				"zod": "^3.25.76"
 			},
 			"bin": {
@@ -30,6 +32,7 @@
 				"@types/cors": "^2.8.19",
 				"@types/express": "^5.0.3",
 				"@types/jest": "^30.0.0",
+				"@types/jmespath": "^0.15.2",
 				"@types/node": "^24.3.1",
 				"@typescript-eslint/eslint-plugin": "^8.43.0",
 				"@typescript-eslint/parser": "^8.43.0",
@@ -2222,6 +2225,12 @@
 				"@sinonjs/commons": "^3.0.1"
 			}
 		},
+		"node_modules/@toon-format/toon": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/@toon-format/toon/-/toon-2.0.1.tgz",
+			"integrity": "sha512-0oohzByDG/VTvsPT7iCfUdoB6yndopkPulh9Kk76fhV6YReVSGqr6ni5EMSxn3umNyfwylI0nOjLYtjJTIiT0w==",
+			"license": "MIT"
+		},
 		"node_modules/@tybys/wasm-util": {
 			"version": "0.10.0",
 			"resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.0.tgz",
@@ -2385,6 +2394,13 @@
 				"expect": "^30.0.0",
 				"pretty-format": "^30.0.0"
 			}
+		},
+		"node_modules/@types/jmespath": {
+			"version": "0.15.2",
+			"resolved": "https://registry.npmjs.org/@types/jmespath/-/jmespath-0.15.2.tgz",
+			"integrity": "sha512-pegh49FtNsC389Flyo9y8AfkVIZn9MMPE9yJrO9svhq6Fks2MwymULWjZqySuxmctd3ZH4/n7Mr98D+1Qo5vGA==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@types/json-schema": {
 			"version": "7.0.15",
@@ -6820,6 +6836,15 @@
 			},
 			"funding": {
 				"url": "https://github.com/chalk/supports-color?sponsor=1"
+			}
+		},
+		"node_modules/jmespath": {
+			"version": "0.16.0",
+			"resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.16.0.tgz",
+			"integrity": "sha512-9FzQjJ7MATs1tSpnco1K6ayiYE3figslrXA72G2HQ/n76RzvYlofyi5QM+iX4YRs/pu3yzxlVQSST23+dMDknw==",
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">= 0.6.0"
 			}
 		},
 		"node_modules/js-tokens": {

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
 		"@types/cors": "^2.8.19",
 		"@types/express": "^5.0.3",
 		"@types/jest": "^30.0.0",
+		"@types/jmespath": "^0.15.2",
 		"@types/node": "^24.3.1",
 		"@typescript-eslint/eslint-plugin": "^8.43.0",
 		"@typescript-eslint/parser": "^8.43.0",
@@ -75,10 +76,12 @@
 	},
 	"dependencies": {
 		"@modelcontextprotocol/sdk": "^1.17.5",
+		"@toon-format/toon": "^2.0.1",
 		"commander": "^14.0.0",
 		"cors": "^2.8.5",
 		"dotenv": "^17.2.2",
 		"express": "^5.1.0",
+		"jmespath": "^0.16.0",
 		"zod": "^3.25.76"
 	},
 	"publishConfig": {

--- a/src/cli/ipaddress.cli.ts
+++ b/src/cli/ipaddress.cli.ts
@@ -27,6 +27,15 @@ function register(program: Command) {
 			'--no-use-https', // commander creates a 'useHttps' boolean, defaulting to true
 			'Use HTTP instead of HTTPS for the API call.',
 		)
+		.option(
+			'--jq <expression>',
+			'JMESPath expression to filter/transform the response.',
+		)
+		.option(
+			'-o, --output-format <format>',
+			'Output format: "toon" (default, token-efficient) or "json".',
+			'toon',
+		)
 		.action(async (ipAddress, options) => {
 			const actionLogger = logger.forMethod('action:get-ip-details');
 			try {
@@ -40,6 +49,8 @@ function register(program: Command) {
 					ipAddress,
 					includeExtendedData: options.includeExtendedData || false,
 					useHttps: options.useHttps, // commander handles the default via --no-use-https
+					jq: options.jq,
+					outputFormat: options.outputFormat as 'toon' | 'json',
 				};
 
 				const result = await ipAddressController.get(args);

--- a/src/tools/ipaddress.tool.ts
+++ b/src/tools/ipaddress.tool.ts
@@ -80,7 +80,29 @@ function registerTools(server: McpServer) {
 
 	server.tool(
 		'ip_get_details',
-		`Retrieves detailed geolocation and network information for a public IP address (\`ipAddress\`). If no IP is provided, automatically uses the server's current public IP. Returns comprehensive location data including country, region, city, coordinates, timezone, and network details like ISP and organization. Use \`includeExtendedData\` to get additional information such as ASN, mobile/proxy detection (requires API token). **Note:** Cannot lookup private IPs (e.g., 192.168.x.x, 10.x.x.x). Powered by ip-api.com. Enable \`useHttps\` for secure connections (required for paid tier).`,
+		`Retrieve geolocation and network information for a public IP address. Returns TOON format by default (30-60% fewer tokens than JSON).
+
+**IMPORTANT - Cost Optimization:**
+- Use \`jq\` param to extract only needed fields. Unfiltered responses are expensive!
+- Example: \`jq: "{ip: query, country: country, city: city}"\` - extract specific fields
+- If unsure about available fields, first call WITHOUT jq filter to see all fields, then use jq in subsequent calls
+
+**Schema Discovery Pattern:**
+1. First call: \`ipAddress: "8.8.8.8"\` (no jq) - explore available fields
+2. Then use: \`jq: "{ip: query, location: {city: city, country: country}}"\` - extract only what you need
+
+**Output format:** TOON (default, token-efficient) or JSON (\`outputFormat: "json"\`)
+
+**Parameters:**
+- \`ipAddress\` - IP to lookup (omit for current device's public IP)
+- \`includeExtendedData\` - Include ASN, host, proxy detection (requires API token)
+- \`useHttps\` - Use HTTPS (default: true)
+- \`jq\` - JMESPath expression to filter response
+- \`outputFormat\` - "toon" (default) or "json"
+
+**JQ examples:** \`query\` (IP only), \`{ip: query, country: country}\`, \`{location: {lat: lat, lon: lon}}\`
+
+**Note:** Cannot lookup private IPs (192.168.x.x, 10.x.x.x). Powered by ip-api.com.`,
 		GetIpDetailsToolSchema.shape,
 		handleGetIpDetails,
 	);

--- a/src/tools/ipaddress.types.ts
+++ b/src/tools/ipaddress.types.ts
@@ -1,6 +1,18 @@
 import { z } from 'zod';
 
 /**
+ * Output format options for API responses
+ * - toon: Token-Oriented Object Notation (default, more token-efficient for LLMs)
+ * - json: Standard JSON format
+ */
+export const OutputFormat = z
+	.enum(['toon', 'json'])
+	.optional()
+	.describe(
+		'Output format: "toon" (default, 30-60% fewer tokens) or "json". TOON is optimized for LLMs with tabular arrays and minimal syntax.',
+	);
+
+/**
  * Zod schema for the IP address tool arguments.
  */
 export const IpAddressToolArgs = z
@@ -19,6 +31,13 @@ export const IpAddressToolArgs = z
 			.optional()
 			.default(true)
 			.describe('Whether to use HTTPS for the API call (recommended).'),
+		jq: z
+			.string()
+			.optional()
+			.describe(
+				'JMESPath expression to filter/transform the response. IMPORTANT: Always use this to extract only needed fields and reduce token costs. Examples: "{ip: query, country: country}" (extract specific fields), "lat" (single field). See https://jmespath.org',
+			),
+		outputFormat: OutputFormat,
 	})
 	.strict();
 

--- a/src/utils/jq.util.ts
+++ b/src/utils/jq.util.ts
@@ -1,0 +1,91 @@
+import jmespath from 'jmespath';
+import { Logger } from './logger.util.js';
+import { toToonOrJson } from './toon.util.js';
+
+const logger = Logger.forContext('utils/jq.util.ts');
+
+/**
+ * Apply a JMESPath filter to JSON data
+ *
+ * @param data - The data to filter (any JSON-serializable value)
+ * @param filter - JMESPath expression to apply
+ * @returns Filtered data or original data if filter is empty/invalid
+ *
+ * @example
+ * // Get single field
+ * applyJqFilter(data, "name")
+ *
+ * // Get nested field
+ * applyJqFilter(data, "body.storage.value")
+ *
+ * // Get multiple fields as object
+ * applyJqFilter(data, "{id: id, title: title}")
+ *
+ * // Array operations
+ * applyJqFilter(data, "results[*].title")
+ */
+export function applyJqFilter(data: unknown, filter?: string): unknown {
+	const methodLogger = logger.forMethod('applyJqFilter');
+
+	// Return original data if no filter provided
+	if (!filter || filter.trim() === '') {
+		methodLogger.debug('No filter provided, returning original data');
+		return data;
+	}
+
+	try {
+		methodLogger.debug(`Applying JMESPath filter: ${filter}`);
+		const result = jmespath.search(data, filter);
+		methodLogger.debug('Filter applied successfully');
+		return result;
+	} catch (error) {
+		methodLogger.error(`Invalid JMESPath expression: ${filter}`, error);
+		// Return original data with error info if filter is invalid
+		return {
+			_jqError: `Invalid JMESPath expression: ${filter}`,
+			_originalData: data,
+		};
+	}
+}
+
+/**
+ * Convert data to JSON string for MCP response
+ *
+ * @param data - The data to stringify
+ * @param pretty - Whether to pretty-print the JSON (default: true)
+ * @returns JSON string
+ */
+export function toJsonString(data: unknown, pretty: boolean = true): string {
+	if (pretty) {
+		return JSON.stringify(data, null, 2);
+	}
+	return JSON.stringify(data);
+}
+
+/**
+ * Convert data to output string for MCP response
+ *
+ * By default, converts to TOON format (Token-Oriented Object Notation)
+ * for improved LLM token efficiency (30-60% fewer tokens).
+ * Falls back to JSON if TOON conversion fails or if useToon is false.
+ *
+ * @param data - The data to convert
+ * @param useToon - Whether to use TOON format (default: true)
+ * @param pretty - Whether to pretty-print JSON (default: true)
+ * @returns TOON formatted string (default), or JSON string
+ */
+export async function toOutputString(
+	data: unknown,
+	useToon: boolean = true,
+	pretty: boolean = true,
+): Promise<string> {
+	const jsonString = toJsonString(data, pretty);
+
+	// Return JSON directly if TOON is not requested
+	if (!useToon) {
+		return jsonString;
+	}
+
+	// Try TOON conversion with JSON fallback
+	return toToonOrJson(data, jsonString);
+}

--- a/src/utils/toon.util.ts
+++ b/src/utils/toon.util.ts
@@ -1,0 +1,76 @@
+import { Logger } from './logger.util.js';
+
+const logger = Logger.forContext('utils/toon.util.ts');
+
+/**
+ * Type definition for the TOON encode function
+ */
+type ToonEncode = (input: unknown, options?: { indent?: number }) => string;
+
+/**
+ * Cached TOON encoder to avoid repeated dynamic imports
+ */
+let toonEncode: ToonEncode | null = null;
+
+/**
+ * Dynamically loads the TOON encoder module.
+ * Uses dynamic import because @toon-format/toon is an ESM-only package.
+ *
+ * @returns Promise resolving to the encode function or null if loading fails
+ */
+async function loadToonEncoder(): Promise<ToonEncode | null> {
+	const methodLogger = logger.forMethod('loadToonEncoder');
+
+	// Return cached encoder if available
+	if (toonEncode) {
+		return toonEncode;
+	}
+
+	try {
+		methodLogger.debug('Loading TOON encoder module...');
+		// Dynamic import for ESM module in CommonJS project
+		const toon = await import('@toon-format/toon');
+		toonEncode = toon.encode;
+		methodLogger.debug('TOON encoder loaded successfully');
+		return toonEncode;
+	} catch (error) {
+		methodLogger.error('Failed to load TOON encoder', error);
+		return null;
+	}
+}
+
+/**
+ * Convert data to TOON format with JSON fallback.
+ *
+ * TOON (Token-Oriented Object Notation) is 30-60% more token-efficient than JSON
+ * for tabular data, making it ideal for LLM responses.
+ *
+ * @param data - The data to convert
+ * @param jsonFallback - JSON string to return if TOON encoding fails
+ * @returns TOON formatted string, or JSON fallback on failure
+ *
+ * @example
+ * const json = JSON.stringify(data, null, 2);
+ * const output = await toToonOrJson(data, json);
+ */
+export async function toToonOrJson(
+	data: unknown,
+	jsonFallback: string,
+): Promise<string> {
+	const methodLogger = logger.forMethod('toToonOrJson');
+
+	try {
+		const encode = await loadToonEncoder();
+		if (!encode) {
+			methodLogger.debug('TOON encoder not available, using JSON fallback');
+			return jsonFallback;
+		}
+
+		const result = encode(data, { indent: 2 });
+		methodLogger.debug('Successfully converted to TOON format');
+		return result;
+	} catch (error) {
+		methodLogger.error('TOON encoding failed, using JSON fallback', error);
+		return jsonFallback;
+	}
+}


### PR DESCRIPTION
## Summary
- Add TOON (Token-Oriented Object Notation) as default output format for improved LLM token efficiency (30-60% fewer tokens than JSON)
- Add JMESPath (jq) filtering to extract only needed fields from responses
- Add `outputFormat` parameter to toggle between TOON and JSON
- Update tool descriptions with cost optimization guidance and schema discovery patterns

## Changes
- **New**: `src/utils/toon.util.ts` - TOON encoder with JSON fallback
- **New**: `src/utils/jq.util.ts` - JMESPath filter and output utilities
- **Updated**: Tool args, controller, CLI, and tool descriptions

## Test plan
- [x] Build succeeds
- [x] TOON output format works (default)
- [x] JSON output format works (`outputFormat: "json"`)
- [x] JMESPath filtering works with TOON
- [x] JMESPath filtering works with JSON
- [x] CLI options work (`--jq`, `--output-format`)

This aligns the boilerplate with Atlassian MCP server implementations.